### PR TITLE
Fixed '.gitkeep' and more

### DIFF
--- a/src/App.java
+++ b/src/App.java
@@ -9,7 +9,7 @@ public class App{
     public static void main(String[] args) {
         // FileModifier.modifyContentOfFile("example.txt", TRANSCRIPTION);
         // FileModifier.modifyContentOfAllFiles(CENSOR);
-        // FileModifier.renameFile("example.md", REPLACE_EXTENSION);
+        // FileModifier.renameFile("example.txt", REPLACE_EXTENSION);
         // FileModifier.renameFile("example.txt", "example.md");
         // FileModifier.renameAllFiles(REPLACE_EXTENSION);
         }

--- a/src/constants/ConfigConstants.java
+++ b/src/constants/ConfigConstants.java
@@ -2,10 +2,10 @@ package constants;
 
 public class ConfigConstants {
     // Files configurations
-    public static final String GIT_KEEP = ".gitkeep";
     public static final String RESULT_EXTENSION = ".txt";
-    public static final String INPUT_FOLDER = "./.Input/";
-    public static final String OUTPUT_FOLDER = "./.Output/";
+    public static final String GIT_KEEP         = ".gitkeep";
+    public static final String INPUT_FOLDER     = "./.Input/";
+    public static final String OUTPUT_FOLDER    = "./.Output/";
 
 
     // Logging configurations

--- a/src/constants/RegEx.java
+++ b/src/constants/RegEx.java
@@ -10,7 +10,8 @@ public class RegEx {
     public static final String REGEX_BOUNDARY = "\\b";
     public static final String FILE_EXTENSION = "\\.\\w+$";
 
-    public static final Set<String> BAD_WORDS = Set.of("fuck", "fucking", "fucked");
+    public static final Set<String> BAD_WORDS = Set.of(
+        "fuck", "fucking", "fucked", "fucks");
     
     private RegEx() {
         throw new IllegalStateException("Utility class");

--- a/src/io/FileIO.java
+++ b/src/io/FileIO.java
@@ -24,7 +24,7 @@ public class FileIO {
 
         } catch (IOException e) {
             ConsoleLogger.logError("An error occurred. (reading)", e);
-            return "";
+            return null;
         }
         if ((content.length() == 0)) {
             ConsoleLogger.log("The file is empty.");

--- a/src/modification/FileModifier.java
+++ b/src/modification/FileModifier.java
@@ -7,15 +7,17 @@ import java.io.File;
 
 public interface FileModifier {
     public static void modifyContentOfFile(String fileName, ModifierType regEx) {
-        if (fileName.equals(ConfigConstants.GIT_KEEP)) {
-            return; // Skips the '.gitkeep' file
-        }
+        if (fileName.equals(ConfigConstants.GIT_KEEP)) return; // Skips the '.gitkeep' file
+
         String path = ConfigConstants.INPUT_FOLDER + fileName;
         String newPath = ConfigConstants.OUTPUT_FOLDER + ModifierType.REPLACE_EXTENSION.modify(fileName);
         String text;
 
         verifyFolders();
         text = FileIO.read(path);
+
+        if(text == null) return;
+
         text = regEx.modify(text);
 
         FileIO.write(newPath, text);
@@ -27,15 +29,19 @@ public interface FileModifier {
 
         for (File file : files) {
             if (file.isFile()) {
-                modifyContentOfFile(file.getPath(), regEx);
+                modifyContentOfFile(file.getName(), regEx);
             }
         }
     }
 
     public static void renameFile(String fileName, ModifierType type) {
+        if (fileName.equals(ConfigConstants.GIT_KEEP)) return; // Skips the '.gitkeep' file
+        
         verifyFolders();
         String text = FileIO.read(ConfigConstants.INPUT_FOLDER + fileName);
         String newPath = ConfigConstants.OUTPUT_FOLDER + type.modify(fileName);
+
+        if (text == null) return;
 
         FileIO.write(newPath, text);
     }
@@ -44,6 +50,8 @@ public interface FileModifier {
         verifyFolders();
         String text = FileIO.read(ConfigConstants.INPUT_FOLDER + oldFileName);
         String newPath = ConfigConstants.OUTPUT_FOLDER + newFileName;
+
+        if (text == null) return;
 
         FileIO.write(newPath, text);
     }

--- a/src/modification/ModifierType.java
+++ b/src/modification/ModifierType.java
@@ -63,6 +63,6 @@ public enum ModifierType {
     }
 
     private static String removeBeginningGap(String text) {
-        return text.replaceFirst(RegEx.NEW_LINE + "+", "");
+        return text.replaceFirst(RegEx.MULTIPLE_EMPTY_LINES, "");
     }
 }


### PR DESCRIPTION
.gitkeep should no longer be read when an 'allFiles' method is called. The app should no longer try to write a file if it failed to read it. The TRANSCRIPTION type should now correctly remove empty lines from beginning of a file.